### PR TITLE
Issue #763 fix

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,7 @@ class OpenALConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        if self.settings.compiler != 'Visual Studio':
+        if self.settings.os != "Windows":
             cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.fPIC
         cmake.definitions['LIBTYPE'] = 'SHARED' if self.options.shared else 'STATIC'
         cmake.configure()


### PR DESCRIPTION
closes: https://github.com/bincrafters/community/issues/763
Fixes the issue #763 that makes it impossible to build on Windows with GCC.