### PR TITLE
Fix linker errors in win64 when using dsound backend

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -59,7 +59,7 @@ class OpenALConan(ConanFile):
 
     def package_info(self):
         if self.settings.os == "Windows":
-            self.cpp_info.libs = ["OpenAL32", 'winmm']
+            self.cpp_info.libs = ["OpenAL32", 'winmm', 'OLE32', 'Shell32']
         else:
             self.cpp_info.libs = ["openal"]
         if self.settings.os == 'Linux':


### PR DESCRIPTION
(affected package: qt/5.13.1 with qtmultimedia)

Check https://github.com/bincrafters/community/issues/953 for further details. 